### PR TITLE
fix: disable eslint for legacy JS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   extends: ['eslint-config-airbnb-base'],
+  ignorePatterns: ['**/js-legacy/**/*.js'],
   parserOptions: {
     ecmaVersion: 10,
     sourceType: 'module',


### PR DESCRIPTION
Ahoj, 

navrhuji staré legacy JS odebrat z lintování a ponechat ho pouze pro nově vytvářené JS.

Co myslíš? 